### PR TITLE
compile files in mbedtls directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC = g++
 RM = rm -rf
 
+
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 
 OBJ_DIR := ./obj
@@ -12,21 +13,26 @@ SRC_FILES := $(sort $(foreach var, $(SRC_DIRS), $(wildcard $(var)/*.cpp)))
 OBJ_FILES := $(patsubst %.cpp, $(OBJ_DIR)/%.o, $(notdir $(SRC_FILES)))
 DEP_FILES = $(OBJ_FILES:.o=.d)
 
+
 INC = -I. -Ipc/ -Isrc/
 
-CPPFLAGS = -std=c++17 -O2 -Wall -g3 $(INC)
-LDFLAGS = -lmbedtls -lmbedcrypto -lmbedx509
+CPPFLAGS = -std=c++17 -Os -Wall -g3 $(INC)
+LDFLAGS = -Wl,-Bdynamic -lpthread
+
+LIBS=mbedtls.a
 
 TARGET=main
 
 $(OBJ_DIR)/%.o:  
 	$(CC) $(CPPFLAGS) -c -o $@ $(filter %/$(strip $(patsubst %.o, %.cpp, $(notdir $@))), $(SRC_FILES))
 
-all:  $(OBJ_FILES)
+all:  $(OBJ_FILES) $(LIBS)
 	$(CC) -o $(TARGET) $^ $(LDFLAGS)
 
+include mbedtls.mk
+
 clean:
-	$(RM) $(OBJ_FILES) $(DEP_FILES) $(TARGET)
+	$(RM) $(OBJ_FILES) $(DEP_FILES) $(TARGET) $(MBEDTLS_OBJ) mbedtls.a
 	
 testpy:
 	#cd ./pytest

--- a/mbedtls.mk
+++ b/mbedtls.mk
@@ -14,11 +14,12 @@ _SRCS=aes.c asn1parse.c asn1write.c \
 MBEDTLS_SRCS := $(foreach var, $(_SRCS), $(MBEDTLS_DIR)$(var))
 
 MBEDTLS_INCLUDE= -Imbedtls/include/   -Imbedtls/include/mbedtls
+MBEDTLS_CONFIG= -I. -DMBEDTLS_CONFIG_FILE=\"mbedtls_config.h\"
 
 MBEDTLS_OBJ = $(MBEDTLS_SRCS:.c=.o)
 
 $(MBEDTLS_DIR)%.o:  $(MBEDTLS_DIR)%.c
-	gcc  $^ -o $@ $(MBEDTLS_INCLUDE) -c -Os -fdata-sections -ffunction-sections
+	gcc  $^ -o $@ $(MBEDTLS_INCLUDE) $(MBEDTLS_CONFIG) -c -Os -fdata-sections -ffunction-sections
 
 
 mbedtls.a: $(MBEDTLS_DIR) $(MBEDTLS_OBJ)

--- a/mbedtls.mk
+++ b/mbedtls.mk
@@ -1,0 +1,29 @@
+
+MBEDTLS_DIR=mbedtls/library/
+_SRCS=aes.c asn1parse.c asn1write.c \
+            bignum.c \
+            ccm.c cipher.c cipher_wrap.c ctr_drbg.c \
+            dhm.c ecdh.c ecdsa.c ecp.c \
+            ecp_curves.c entropy.c entropy_poll.c \
+            havege.c md.c md2.c md4.c md5.c \
+            md_wrap.c oid.c \
+            rsa_internal.c \
+            sha1.c rsa.c sha256.c sha512.c
+
+# MBEDTLS_SRCS := $(patsubst %.cpp, $(OBJ_DIR)/%.cpp, $(notdir $(_SRCS)))
+MBEDTLS_SRCS := $(foreach var, $(_SRCS), $(MBEDTLS_DIR)$(var))
+
+MBEDTLS_INCLUDE= -Imbedtls/include/   -Imbedtls/include/mbedtls
+
+MBEDTLS_OBJ = $(MBEDTLS_SRCS:.c=.o)
+
+$(MBEDTLS_DIR)%.o:  $(MBEDTLS_DIR)%.c
+	gcc  $^ -o $@ $(MBEDTLS_INCLUDE) -c -Os -fdata-sections -ffunction-sections
+
+
+mbedtls.a: $(MBEDTLS_DIR) $(MBEDTLS_OBJ)
+	ar -rc  mbedtls.a $(MBEDTLS_OBJ)  
+	ar -s mbedtls.a
+
+$(MBEDTLS_DIR):
+	echo "Error: need to download mbedtls."

--- a/mbedtls.mk
+++ b/mbedtls.mk
@@ -7,7 +7,7 @@ _SRCS=aes.c asn1parse.c asn1write.c \
             ecp_curves.c entropy.c entropy_poll.c \
             havege.c md.c md2.c md4.c md5.c \
             md_wrap.c oid.c \
-            rsa_internal.c \
+            rsa_internal.c platform_util.c \
             sha1.c rsa.c sha256.c sha512.c
 
 # MBEDTLS_SRCS := $(patsubst %.cpp, $(OBJ_DIR)/%.cpp, $(notdir $(_SRCS)))

--- a/mbedtls_config.h
+++ b/mbedtls_config.h
@@ -1,0 +1,85 @@
+/**
+ * \file config-mini-tls1_1.h
+ *
+ * \brief Minimal configuration for TLS 1.1 (RFC 4346)
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ * Minimal configuration for TLS 1.1 (RFC 4346), implementing only the
+ * required ciphersuite: MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
+ *
+ * See README.txt for usage instructions.
+ */
+
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+/* System support */
+#define MBEDTLS_HAVE_ASM
+#define MBEDTLS_HAVE_TIME
+
+/* mbed TLS feature support */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+#define MBEDTLS_SSL_PROTO_TLS1_1
+
+/* mbed TLS modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_DES_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_MD5_C
+#define MBEDTLS_NET_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_SRV_C
+#define MBEDTLS_SSL_TLS_C
+
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_USE_C
+
+#define MBEDTLS_GENPRIME
+
+
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECP_C
+
+/* For test certificates */
+
+/* For testing with compat.sh */
+
+#include "mbedtls/check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */
+


### PR DESCRIPTION
Change build to use mbedtls sources directly.

Need to download mbedtls release:

```
git clone https://github.com/ARMmbed/mbedtls.git
cd mbedtls
git checkout mbedtls-2.16.0
```

Then build normally.

```
cd ..
make
```