### PR TITLE
Errors in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,13 @@ INC = -I. -Ipc/ -Isrc/ -Ilibs/mbedtls/ -Ilibs/mbedtls/mbedtls/crypto/include/\
 CPPFLAGS = -std=c++17 -Os -Wall -g3 $(INC)
 LDFLAGS = -Wl,-Bdynamic -lpthread
 
-LIBS=libs/mbedtls/mbedtls.a
-
 TARGET=openpgp_test
 
 $(OBJ_DIR)/%.o:  
 	$(CC) $(CPPFLAGS) -c -o $@ $(filter %/$(strip $(patsubst %.o, %.cpp, $(notdir $@))), $(SRC_FILES))
 
-all:  $(OBJ_FILES) $(LIBS)
+all:  $(OBJ_FILES)
 	$(CC) -o $(TARGET) $^ $(LDFLAGS)
-
-include libs/mbedtls/mbedtls.mk
 
 clean:
 	$(RM) $(OBJ_FILES) $(DEP_FILES) $(TARGET) $(MBEDTLS_OBJ) $(MBEDTLS_A)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 
 OBJ_DIR := ./obj
 SRC_DIRS := ./pc \
-			./src \
+            ./src \
             ./src/applications \
             ./src/applications/openpgp \
             ./libs/stm32fs
@@ -34,8 +34,8 @@ all:  $(OBJ_FILES) $(LIBS)
 include libs/mbedtls/mbedtls.mk
 
 clean:
-    $(RM) $(OBJ_FILES) $(DEP_FILES) $(TARGET) $(MBEDTLS_OBJ) $(MBEDTLS_A)
-	
+	$(RM) $(OBJ_FILES) $(DEP_FILES) $(TARGET) $(MBEDTLS_OBJ) $(MBEDTLS_A)
+
 testpy:
 	#cd ./pytest
 	cd ~/solo/gnuk/tests; py.test-3 -x


### PR DESCRIPTION
Is anyone maintaining Makefile, I can't build it on either Ubuntu or macOS.

```bash
In file included from ./pc/main.cpp:16:
In file included from src/solofactory.h:14:
src/cryptolib.h:19:10: fatal error: 'bearssl.h' file not found
#include "bearssl.h"
         ^~~~~~~~~~~
2 errors generated.
make: *** [obj/main.o] Error 1
```